### PR TITLE
Enemy Attack ( Damage, Spawn, Collider) + fix Bug Enemy Attack

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -39,930 +39,6 @@ Transform:
   - {fileID: 3919404425659971472}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2134004415745001833
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5048220407788327654}
-  - component: {fileID: 3132376932071663614}
-  - component: {fileID: 8318215865026367275}
-  - component: {fileID: 1151534296177539521}
-  - component: {fileID: 5631623905222028654}
-  - component: {fileID: 8781185152789349708}
-  - component: {fileID: 6396408156532292927}
-  - component: {fileID: 1496776652039068325}
-  - component: {fileID: 2604674311820489501}
-  m_Layer: 0
-  m_Name: Level1
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5048220407788327654
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3.19, y: -3.11, z: -0.036899365}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8738994752749581050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &3132376932071663614
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 2
-  m_Sprite: {fileID: 1531760307, guid: e050f47f5d3bc5e45a545dca8db24853, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.76, y: 0.57}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!111 &8318215865026367275
-Animation:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Animation: {fileID: 0}
-  m_Animations: []
-  m_WrapMode: 0
-  m_PlayAutomatically: 1
-  m_AnimatePhysics: 0
-  m_CullingType: 0
---- !u!95 &1151534296177539521
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 39daacf5c9a66fb4c938f3ae6bdfa6bf, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!61 &5631623905222028654
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 0.76, y: 0.57}
-    newSize: {x: 0.76, y: 0.57}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.76, y: 0.57}
-  m_EdgeRadius: 0
---- !u!114 &8781185152789349708
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f03faf0235ad904eb1f99f77315f268, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 1
-  currentHealth: 1
---- !u!114 &6396408156532292927
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c3112bfd540b7db4d81123d4183f4831, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  droppedItemPrefab: {fileID: 1495125997846032468, guid: 7dce1674de8a7944baad39755079ab2a, type: 3}
-  itemList:
-  - {fileID: 11400000, guid: 9d4952e858225c742a13b8d8d4612b5f, type: 2}
-  - {fileID: 11400000, guid: 475504ac44a54cb4b8c00efd28331907, type: 2}
-  - {fileID: 11400000, guid: 5caa4c8d02faa15468a608480446b93f, type: 2}
-  - {fileID: 11400000, guid: ddc1cddaf8573194db79d621d756d069, type: 2}
-  - {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
---- !u!114 &1496776652039068325
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 505c540940ca2354db55227a8566044f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  minX: -8.31
-  maxX: 6.24
-  minY: -2.95
-  maxY: -1.42
-  speed: 2
-  damageTouch: 1
-  POINTS: 1
---- !u!50 &2604674311820489501
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2134004415745001833}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!1 &4041346463774990076
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2538609271462115025}
-  - component: {fileID: 4394071692437006513}
-  m_Layer: 0
-  m_Name: EL1Pool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2538609271462115025
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4041346463774990076}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8738994752749581050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &4394071692437006513
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4041346463774990076}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d35d386895b1561498689488245a8d50, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  amountToPool: 1
-  el1Prefab: {fileID: 2134004415745001833}
-  spawnInterval: 3
---- !u!1 &4144119253303293720
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7178123765006333313}
-  - component: {fileID: 3778331309704673444}
-  - component: {fileID: 7931678475342849906}
-  m_Layer: 0
-  m_Name: EL2Pool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7178123765006333313
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4144119253303293720}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8738994752749581050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &3778331309704673444
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4144119253303293720}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d35d386895b1561498689488245a8d50, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  amountToPool: 1
-  el1Prefab: {fileID: 4693973507867095042}
-  spawnInterval: 3
---- !u!114 &7931678475342849906
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4144119253303293720}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95d8298d7f3f393448b72e5febb9f4ee, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  amountToPool: 3
-  enemyAttackPrefab: {fileID: 4266974105949582496}
---- !u!1 &4693973507867095042
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3179457959491997140}
-  - component: {fileID: 5677064909590087311}
-  - component: {fileID: 2818279847752143372}
-  - component: {fileID: 8884189712385150241}
-  - component: {fileID: 1156211320750425109}
-  - component: {fileID: 6377176260293760725}
-  - component: {fileID: 5400342437388194770}
-  - component: {fileID: 2523520684820885268}
-  - component: {fileID: 5739742757219822577}
-  m_Layer: 0
-  m_Name: Level2
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &3179457959491997140
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.64, y: -4.75, z: -0.036899365}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8738994752749581050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &5677064909590087311
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 3
-  m_Sprite: {fileID: -692717035, guid: 8f9dfd76f39d86340926dcb77e4e70a9, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 1
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.37, y: 0.57}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!95 &2818279847752143372
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 66eb660460554de4dafbda8b4de86c75, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!111 &8884189712385150241
-Animation:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Animation: {fileID: 0}
-  m_Animations: []
-  m_WrapMode: 0
-  m_PlayAutomatically: 1
-  m_AnimatePhysics: 0
-  m_CullingType: 0
---- !u!61 &1156211320750425109
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.15495098, y: -0.3009627}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.5416666, y: 2.375}
-    newSize: {x: 0.37, y: 0.57}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.8384268, y: 1.5823655}
-  m_EdgeRadius: 0
---- !u!114 &6377176260293760725
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f03faf0235ad904eb1f99f77315f268, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 2
-  currentHealth: 2
---- !u!114 &5400342437388194770
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c3112bfd540b7db4d81123d4183f4831, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  droppedItemPrefab: {fileID: 1495125997846032468, guid: 7dce1674de8a7944baad39755079ab2a, type: 3}
-  itemList:
-  - {fileID: 11400000, guid: 9d4952e858225c742a13b8d8d4612b5f, type: 2}
-  - {fileID: 11400000, guid: 475504ac44a54cb4b8c00efd28331907, type: 2}
-  - {fileID: 11400000, guid: 5caa4c8d02faa15468a608480446b93f, type: 2}
-  - {fileID: 11400000, guid: ddc1cddaf8573194db79d621d756d069, type: 2}
-  - {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
---- !u!114 &2523520684820885268
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 505c540940ca2354db55227a8566044f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  minX: -8.31
-  maxX: 6.24
-  minY: -2.95
-  maxY: -1.42
-  speed: 2
-  damageTouch: 2
-  POINTS: 2
---- !u!50 &5739742757219822577
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4693973507867095042}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
---- !u!1 &5831877782881205522
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5376668609046041451}
-  - component: {fileID: 6400661306318365079}
-  - component: {fileID: 4033685222774659263}
-  m_Layer: 0
-  m_Name: EL3Pool
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5376668609046041451
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5831877782881205522}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8738994752749581050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6400661306318365079
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5831877782881205522}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d35d386895b1561498689488245a8d50, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  amountToPool: 1
-  el1Prefab: {fileID: 5911178239327700724}
-  spawnInterval: 3
---- !u!114 &4033685222774659263
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5831877782881205522}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 95d8298d7f3f393448b72e5febb9f4ee, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  amountToPool: 3
-  enemyAttackPrefab: {fileID: 3860448963068251390}
---- !u!1 &5911178239327700724
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1405161221182070335}
-  - component: {fileID: 568341452122887076}
-  - component: {fileID: 1039733157031215064}
-  - component: {fileID: 3516135812883320938}
-  - component: {fileID: 8064252019050526294}
-  - component: {fileID: 288595188567981873}
-  - component: {fileID: 7378135884334467485}
-  - component: {fileID: 1248092641406137099}
-  - component: {fileID: 855344692822016914}
-  m_Layer: 0
-  m_Name: Level3
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1405161221182070335
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.9, y: -1.7, z: -0.036899365}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8738994752749581050}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &568341452122887076
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 2
-  m_Sprite: {fileID: 2129611561, guid: 3cfc6896d23100f4da389421b63c5e7c, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 1
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 0.39, y: 0.52}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!111 &1039733157031215064
-Animation:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Animation: {fileID: 0}
-  m_Animations: []
-  m_WrapMode: 0
-  m_PlayAutomatically: 1
-  m_AnimatePhysics: 0
-  m_CullingType: 0
---- !u!95 &3516135812883320938
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 6d630224072591c43a0c58366daa43bc, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!61 &8064252019050526294
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0.18176949, y: -0.13111228}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.625, y: 2.1666667}
-    newSize: {x: 0.39, y: 0.52}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1.261461, y: 1.987877}
-  m_EdgeRadius: 0
---- !u!114 &288595188567981873
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f03faf0235ad904eb1f99f77315f268, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  maxHealth: 3
-  currentHealth: 3
---- !u!114 &7378135884334467485
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c3112bfd540b7db4d81123d4183f4831, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  droppedItemPrefab: {fileID: 1495125997846032468, guid: 7dce1674de8a7944baad39755079ab2a, type: 3}
-  itemList:
-  - {fileID: 11400000, guid: 9d4952e858225c742a13b8d8d4612b5f, type: 2}
-  - {fileID: 11400000, guid: 475504ac44a54cb4b8c00efd28331907, type: 2}
-  - {fileID: 11400000, guid: 5caa4c8d02faa15468a608480446b93f, type: 2}
-  - {fileID: 11400000, guid: ddc1cddaf8573194db79d621d756d069, type: 2}
-  - {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
---- !u!114 &1248092641406137099
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 505c540940ca2354db55227a8566044f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  minX: -8.31
-  maxX: 6.24
-  minY: -2.95
-  maxY: -1.42
-  speed: 2
-  damageTouch: 3
-  POINTS: 3
---- !u!50 &855344692822016914
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5911178239327700724}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 4
 --- !u!1001 &364171340433093167
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1022,17 +98,481 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4484069758728029839, guid: 85d002ac7f40eaf4397e45b3926fbfd0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 904446690397671571}
+    - targetCorrespondingSourceObject: {fileID: 4484069758728029839, guid: 85d002ac7f40eaf4397e45b3926fbfd0, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5850931690664254260}
   m_SourcePrefab: {fileID: 100100000, guid: 85d002ac7f40eaf4397e45b3926fbfd0, type: 3}
 --- !u!1 &4266974105949582496 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4484069758728029839, guid: 85d002ac7f40eaf4397e45b3926fbfd0, type: 3}
   m_PrefabInstance: {fileID: 364171340433093167}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &904446690397671571
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4266974105949582496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a5e2f7195a85964887c28e2701f2d9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 5
+  enemyAttackDamageAmount: 2
+--- !u!61 &5850931690664254260
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4266974105949582496}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.73, y: 0.72}
+    newSize: {x: 0.73, y: 0.72}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.73, y: 0.72}
+  m_EdgeRadius: 0
 --- !u!4 &8876001734249365489 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 9088316185921670622, guid: 85d002ac7f40eaf4397e45b3926fbfd0, type: 3}
   m_PrefabInstance: {fileID: 364171340433093167}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3335869018809006729
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8738994752749581050}
+    m_Modifications:
+    - target: {fileID: 1714109713255796113, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_Name
+      value: EL2Pool
+      objectReference: {fileID: 0}
+    - target: {fileID: 1883691550097637933, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: el1Prefab
+      value: 
+      objectReference: {fileID: 4693973507867095042}
+    - target: {fileID: 1883691550097637933, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: amountToPool
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4636905234780347899, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: amountToPool
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4636905234780347899, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: enemyAttackPrefab
+      value: 
+      objectReference: {fileID: 4266974105949582496}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+--- !u!4 &7178123765006333313 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5608866900649611016, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+  m_PrefabInstance: {fileID: 3335869018809006729}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7931678475342849906 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4636905234780347899, guid: 5d1ba815770332b42bcb07868c8b8adc, type: 3}
+  m_PrefabInstance: {fileID: 3335869018809006729}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95d8298d7f3f393448b72e5febb9f4ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &3749923154216228955
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8738994752749581050}
+    m_Modifications:
+    - target: {fileID: 2364382463917097726, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: isMoving
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2997117549021925682, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_Name
+      value: Level1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.19
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -3.11
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.036899365
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+--- !u!1 &2134004415745001833 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2997117549021925682, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+  m_PrefabInstance: {fileID: 3749923154216228955}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &5048220407788327654 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8215839553870351037, guid: a711a710ac47c4c4f9e23e08bc62dda0, type: 3}
+  m_PrefabInstance: {fileID: 3749923154216228955}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3996464495958510855
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8738994752749581050}
+    m_Modifications:
+    - target: {fileID: 1473543466419495443, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: isMoving
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1473543466419495443, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: attackPool
+      value: 
+      objectReference: {fileID: 7931678475342849906}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.64
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -4.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.036899365
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8525898217925278981, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+      propertyPath: m_Name
+      value: Level2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+--- !u!4 &3179457959491997140 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1975390715514863827, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+  m_PrefabInstance: {fileID: 3996464495958510855}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4693973507867095042 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8525898217925278981, guid: 5d02bf671a9630f43af1afff3383af21, type: 3}
+  m_PrefabInstance: {fileID: 3996464495958510855}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4125604675251753748
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8738994752749581050}
+    m_Modifications:
+    - target: {fileID: 1061601354686630827, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: amountToPool
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 1061601354686630827, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: enemyAttackPrefab
+      value: 
+      objectReference: {fileID: 3860448963068251390}
+    - target: {fileID: 7030857975009112707, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: el1Prefab
+      value: 
+      objectReference: {fileID: 5911178239327700724}
+    - target: {fileID: 7030857975009112707, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: spawnInterval
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7615563235461312006, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_Name
+      value: EL3Pool
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+--- !u!114 &4033685222774659263 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1061601354686630827, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+  m_PrefabInstance: {fileID: 4125604675251753748}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95d8298d7f3f393448b72e5febb9f4ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &5376668609046041451 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8348780926997397631, guid: ec03cede7c1c5d14a9b0107ec8cf2946, type: 3}
+  m_PrefabInstance: {fileID: 4125604675251753748}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5199203922096574749
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8738994752749581050}
+    m_Modifications:
+    - target: {fileID: 1886991895549695977, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_Name
+      value: Level3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6446152787631333910, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: isMoving
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6446152787631333910, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: attackPool
+      value: 
+      objectReference: {fileID: 4033685222774659263}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -1.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.036899365
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+--- !u!4 &1405161221182070335 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6604364769612025634, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+  m_PrefabInstance: {fileID: 5199203922096574749}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5911178239327700724 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1886991895549695977, guid: 912abf33685e0dc409a4b8fc92c59b1b, type: 3}
+  m_PrefabInstance: {fileID: 5199203922096574749}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7116618426255537804
 PrefabInstance:
@@ -1093,15 +633,150 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 6291633270744463986, guid: 27327bffca294f14bb36303d604bb24f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7813575854321962774}
+    - targetCorrespondingSourceObject: {fileID: 6291633270744463986, guid: 27327bffca294f14bb36303d604bb24f, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2712779264844119373}
   m_SourcePrefab: {fileID: 100100000, guid: 27327bffca294f14bb36303d604bb24f, type: 3}
 --- !u!1 &3860448963068251390 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6291633270744463986, guid: 27327bffca294f14bb36303d604bb24f, type: 3}
   m_PrefabInstance: {fileID: 7116618426255537804}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &7813575854321962774
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3860448963068251390}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a5e2f7195a85964887c28e2701f2d9f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  moveSpeed: 5
+  enemyAttackDamageAmount: 3
+--- !u!61 &2712779264844119373
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3860448963068251390}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 2.310345, y: 0.9655172}
+    newSize: {x: 0.67, y: 0.28}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2.310345, y: 0.9655172}
+  m_EdgeRadius: 0
 --- !u!4 &3919404425659971472 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6100067764628324636, guid: 27327bffca294f14bb36303d604bb24f, type: 3}
   m_PrefabInstance: {fileID: 7116618426255537804}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &8481952480690068954
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 8738994752749581050}
+    m_Modifications:
+    - target: {fileID: 5282460936501261675, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: el1Prefab
+      value: 
+      objectReference: {fileID: 2134004415745001833}
+    - target: {fileID: 5282460936501261675, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: amountToPool
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5593556387009430310, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_Name
+      value: EL1Pool
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+--- !u!4 &2538609271462115025 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6237205628876843787, guid: b2799c0d5a9539d40bc04c0d2c9fc951, type: 3}
+  m_PrefabInstance: {fileID: 8481952480690068954}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Enemy/EL1Pool.prefab
+++ b/Assets/Prefabs/Enemy/EL1Pool.prefab
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5593556387009430310
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6237205628876843787}
+  - component: {fileID: 5282460936501261675}
+  m_Layer: 0
+  m_Name: EL1Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6237205628876843787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5593556387009430310}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &5282460936501261675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5593556387009430310}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d35d386895b1561498689488245a8d50, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  amountToPool: 1
+  el1Prefab: {fileID: 0}
+  spawnInterval: 3

--- a/Assets/Prefabs/Enemy/EL1Pool.prefab.meta
+++ b/Assets/Prefabs/Enemy/EL1Pool.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b2799c0d5a9539d40bc04c0d2c9fc951
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/EL2Pool.prefab
+++ b/Assets/Prefabs/Enemy/EL2Pool.prefab
@@ -1,0 +1,64 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1714109713255796113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5608866900649611016}
+  - component: {fileID: 1883691550097637933}
+  - component: {fileID: 4636905234780347899}
+  m_Layer: 0
+  m_Name: EL2Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5608866900649611016
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714109713255796113}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1883691550097637933
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714109713255796113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d35d386895b1561498689488245a8d50, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  amountToPool: 1
+  el1Prefab: {fileID: 0}
+  spawnInterval: 3
+--- !u!114 &4636905234780347899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1714109713255796113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95d8298d7f3f393448b72e5febb9f4ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  amountToPool: 30
+  enemyAttackPrefab: {fileID: 0}

--- a/Assets/Prefabs/Enemy/EL2Pool.prefab.meta
+++ b/Assets/Prefabs/Enemy/EL2Pool.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d1ba815770332b42bcb07868c8b8adc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/EL3Pool.prefab
+++ b/Assets/Prefabs/Enemy/EL3Pool.prefab
@@ -1,0 +1,64 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7615563235461312006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8348780926997397631}
+  - component: {fileID: 7030857975009112707}
+  - component: {fileID: 1061601354686630827}
+  m_Layer: 0
+  m_Name: EL3Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8348780926997397631
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7615563235461312006}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7030857975009112707
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7615563235461312006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d35d386895b1561498689488245a8d50, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  amountToPool: 1
+  el1Prefab: {fileID: 0}
+  spawnInterval: 3
+--- !u!114 &1061601354686630827
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7615563235461312006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 95d8298d7f3f393448b72e5febb9f4ee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  amountToPool: 30
+  enemyAttackPrefab: {fileID: 0}

--- a/Assets/Prefabs/Enemy/EL3Pool.prefab.meta
+++ b/Assets/Prefabs/Enemy/EL3Pool.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ec03cede7c1c5d14a9b0107ec8cf2946
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Level1.prefab
+++ b/Assets/Prefabs/Enemy/Level1.prefab
@@ -1,0 +1,256 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2997117549021925682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8215839553870351037}
+  - component: {fileID: 2265898872306958245}
+  - component: {fileID: 5150528613580822384}
+  - component: {fileID: 4319362619917296026}
+  - component: {fileID: 8803951399538357557}
+  - component: {fileID: 5609073230462819607}
+  - component: {fileID: 7840481531592615268}
+  - component: {fileID: 2364382463917097726}
+  - component: {fileID: 1166377607646096198}
+  m_Layer: 0
+  m_Name: Level1
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &8215839553870351037
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.19, y: -3.11, z: -0.036899365}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2265898872306958245
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 1531760307, guid: e050f47f5d3bc5e45a545dca8db24853, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.76, y: 0.57}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!111 &5150528613580822384
+Animation:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 0}
+  m_Animations: []
+  m_WrapMode: 0
+  m_PlayAutomatically: 1
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!95 &4319362619917296026
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 39daacf5c9a66fb4c938f3ae6bdfa6bf, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!61 &8803951399538357557
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.76, y: 0.57}
+    newSize: {x: 0.76, y: 0.57}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.76, y: 0.57}
+  m_EdgeRadius: 0
+--- !u!114 &5609073230462819607
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f03faf0235ad904eb1f99f77315f268, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 1
+  currentHealth: 1
+--- !u!114 &7840481531592615268
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3112bfd540b7db4d81123d4183f4831, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  droppedItemPrefab: {fileID: 1495125997846032468, guid: 7dce1674de8a7944baad39755079ab2a, type: 3}
+  itemList:
+  - {fileID: 11400000, guid: 9d4952e858225c742a13b8d8d4612b5f, type: 2}
+  - {fileID: 11400000, guid: 475504ac44a54cb4b8c00efd28331907, type: 2}
+  - {fileID: 11400000, guid: 5caa4c8d02faa15468a608480446b93f, type: 2}
+  - {fileID: 11400000, guid: ddc1cddaf8573194db79d621d756d069, type: 2}
+  - {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
+--- !u!114 &2364382463917097726
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b49be5c6cc8670e48b0f29cf7b2518d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minX: -8.31
+  maxX: 6.24
+  minY: -2.95
+  maxY: -1.42
+  speed: 2
+  damageTouch: 1
+  POINTS: 1
+  isAbleAttack: 0
+  attackPool: {fileID: 0}
+  attackInterval: 2.5
+--- !u!50 &1166377607646096198
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2997117549021925682}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Prefabs/Enemy/Level1.prefab.meta
+++ b/Assets/Prefabs/Enemy/Level1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a711a710ac47c4c4f9e23e08bc62dda0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Level2.prefab
+++ b/Assets/Prefabs/Enemy/Level2.prefab
@@ -1,0 +1,256 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8525898217925278981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1975390715514863827}
+  - component: {fileID: 8772650592924502920}
+  - component: {fileID: 1182971011867991819}
+  - component: {fileID: 5493459374228946982}
+  - component: {fileID: 2845706907519027474}
+  - component: {fileID: 8067639414140722130}
+  - component: {fileID: 9045362879396372181}
+  - component: {fileID: 1473543466419495443}
+  - component: {fileID: 8705989042843690742}
+  m_Layer: 0
+  m_Name: Level2
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1975390715514863827
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.64, y: -4.75, z: -0.036899365}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8772650592924502920
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 3
+  m_Sprite: {fileID: -692717035, guid: 8f9dfd76f39d86340926dcb77e4e70a9, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.37, y: 0.57}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &1182971011867991819
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 66eb660460554de4dafbda8b4de86c75, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!111 &5493459374228946982
+Animation:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 0}
+  m_Animations: []
+  m_WrapMode: 0
+  m_PlayAutomatically: 1
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!61 &2845706907519027474
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.15495098, y: -0.3009627}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.5416666, y: 2.375}
+    newSize: {x: 0.37, y: 0.57}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.8384268, y: 1.5823655}
+  m_EdgeRadius: 0
+--- !u!114 &8067639414140722130
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f03faf0235ad904eb1f99f77315f268, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 2
+  currentHealth: 2
+--- !u!114 &9045362879396372181
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3112bfd540b7db4d81123d4183f4831, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  droppedItemPrefab: {fileID: 1495125997846032468, guid: 7dce1674de8a7944baad39755079ab2a, type: 3}
+  itemList:
+  - {fileID: 11400000, guid: 9d4952e858225c742a13b8d8d4612b5f, type: 2}
+  - {fileID: 11400000, guid: 475504ac44a54cb4b8c00efd28331907, type: 2}
+  - {fileID: 11400000, guid: 5caa4c8d02faa15468a608480446b93f, type: 2}
+  - {fileID: 11400000, guid: ddc1cddaf8573194db79d621d756d069, type: 2}
+  - {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
+--- !u!114 &1473543466419495443
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b49be5c6cc8670e48b0f29cf7b2518d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minX: -8.31
+  maxX: 6.24
+  minY: -2.95
+  maxY: -1.42
+  speed: 2
+  damageTouch: 2
+  POINTS: 2
+  isAbleAttack: 1
+  attackPool: {fileID: 0}
+  attackInterval: 2.5
+--- !u!50 &8705989042843690742
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8525898217925278981}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Prefabs/Enemy/Level2.prefab.meta
+++ b/Assets/Prefabs/Enemy/Level2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d02bf671a9630f43af1afff3383af21
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemy/Level3.prefab
+++ b/Assets/Prefabs/Enemy/Level3.prefab
@@ -1,0 +1,256 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1886991895549695977
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6604364769612025634}
+  - component: {fileID: 5747842039669080761}
+  - component: {fileID: 5065027476685074117}
+  - component: {fileID: 8713509321642787191}
+  - component: {fileID: 2868425826781226827}
+  - component: {fileID: 5487077182416711212}
+  - component: {fileID: 3333559917519034496}
+  - component: {fileID: 6446152787631333910}
+  - component: {fileID: 4898090229435355791}
+  m_Layer: 0
+  m_Name: Level3
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &6604364769612025634
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.9, y: -1.7, z: -0.036899365}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5747842039669080761
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 2
+  m_Sprite: {fileID: 2129611561, guid: 3cfc6896d23100f4da389421b63c5e7c, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 1
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.39, y: 0.52}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!111 &5065027476685074117
+Animation:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Animation: {fileID: 0}
+  m_Animations: []
+  m_WrapMode: 0
+  m_PlayAutomatically: 1
+  m_AnimatePhysics: 0
+  m_CullingType: 0
+--- !u!95 &8713509321642787191
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 6d630224072591c43a0c58366daa43bc, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!61 &2868425826781226827
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.18176949, y: -0.13111228}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1.625, y: 2.1666667}
+    newSize: {x: 0.39, y: 0.52}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.261461, y: 1.987877}
+  m_EdgeRadius: 0
+--- !u!114 &5487077182416711212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f03faf0235ad904eb1f99f77315f268, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 3
+  currentHealth: 3
+--- !u!114 &3333559917519034496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3112bfd540b7db4d81123d4183f4831, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  droppedItemPrefab: {fileID: 1495125997846032468, guid: 7dce1674de8a7944baad39755079ab2a, type: 3}
+  itemList:
+  - {fileID: 11400000, guid: 9d4952e858225c742a13b8d8d4612b5f, type: 2}
+  - {fileID: 11400000, guid: 475504ac44a54cb4b8c00efd28331907, type: 2}
+  - {fileID: 11400000, guid: 5caa4c8d02faa15468a608480446b93f, type: 2}
+  - {fileID: 11400000, guid: ddc1cddaf8573194db79d621d756d069, type: 2}
+  - {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
+--- !u!114 &6446152787631333910
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b49be5c6cc8670e48b0f29cf7b2518d8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  minX: -8.31
+  maxX: 6.24
+  minY: -2.95
+  maxY: -1.42
+  speed: 2
+  damageTouch: 3
+  POINTS: 3
+  isAbleAttack: 1
+  attackPool: {fileID: 0}
+  attackInterval: 2.5
+--- !u!50 &4898090229435355791
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1886991895549695977}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Prefabs/Enemy/Level3.prefab.meta
+++ b/Assets/Prefabs/Enemy/Level3.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 912abf33685e0dc409a4b8fc92c59b1b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/EnemyTest.unity
+++ b/Assets/Scenes/EnemyTest.unity
@@ -552,6 +552,67 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 218502246}
   m_CullTransparentMesh: 1
+--- !u!1001 &232644300
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 284318410998759138, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_Name
+      value: Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 6400661306318365079, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: amountToPool
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.0796528
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6681315
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.036899365
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
 --- !u!114 &241229763 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5395992520965551507, guid: f46f9c85a045f6042999d7048fe68568, type: 3}
@@ -4168,79 +4229,6 @@ RectTransform:
   m_AnchoredPosition: {x: 1.5149, y: 120.1}
   m_SizeDelta: {x: 102.6971, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &1011293566
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 284318410998759138, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_Name
-      value: Enemy
-      objectReference: {fileID: 0}
-    - target: {fileID: 5400342437388194770, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: itemList.Array.size
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5400342437388194770, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: itemList.Array.data[4]
-      value: 
-      objectReference: {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
-    - target: {fileID: 6396408156532292927, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: itemList.Array.size
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6396408156532292927, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: itemList.Array.data[4]
-      value: 
-      objectReference: {fileID: 11400000, guid: fce2de84705b40240ade16877cf4d466, type: 2}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 1.0796528
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.6681315
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.036899365
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8738994752749581050, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 9112f8f6f959ec941b2e8be0fca01738, type: 3}
 --- !u!1 &1203238050
 GameObject:
   m_ObjectHideFlags: 0
@@ -5924,11 +5912,11 @@ PrefabInstance:
       objectReference: {fileID: 241229763}
     - target: {fileID: 3620472127950296780, guid: 2da03df6732024243a0a0f724c21d6a6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -3.66
+      value: -3.46
       objectReference: {fileID: 0}
     - target: {fileID: 3620472127950296780, guid: 2da03df6732024243a0a0f724c21d6a6, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.53
+      value: -1.15
       objectReference: {fileID: 0}
     - target: {fileID: 3620472127950296780, guid: 2da03df6732024243a0a0f724c21d6a6, type: 3}
       propertyPath: m_LocalPosition.z
@@ -6104,4 +6092,4 @@ SceneRoots:
   - {fileID: 7489579736350112767}
   - {fileID: 554324493}
   - {fileID: 1760878187}
-  - {fileID: 1011293566}
+  - {fileID: 232644300}

--- a/Assets/Scripts/Enemy/EnemyAttackController.cs
+++ b/Assets/Scripts/Enemy/EnemyAttackController.cs
@@ -4,15 +4,62 @@ using UnityEngine;
 
 public class EnemyAttackController : MonoBehaviour
 {
+    [SerializeField]
+    private float moveSpeed = 5f;
+    [SerializeField]
+    private float enemyAttackDamageAmount;
+    private Vector3 moveDirection;
+    private Transform enemyTransform;
+    private BoxCollider2D boxCollider;
+
     // Start is called before the first frame update
     void Start()
     {
-        
+        moveDirection = Vector3.up;
+        boxCollider = GetComponent<BoxCollider2D>();
     }
 
     // Update is called once per frame
     void Update()
     {
-        
+        Move();
+
+        CheckOutOfBounds();
+
     }
+    void Move()
+    {
+        transform.position += moveDirection * moveSpeed * Time.deltaTime;
+    }
+    void CheckOutOfBounds()
+    {
+        Vector3 viewportPos = Camera.main.WorldToViewportPoint(transform.position);
+        if (viewportPos.x < 0 || viewportPos.x > 1 || viewportPos.y < 0 || viewportPos.y > 1)
+        {
+            gameObject.SetActive(false);
+        }
+    }
+
+    void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("Platform"))
+        {
+            gameObject.SetActive(false);
+        }
+        if (collision.gameObject.tag == "Player")
+        {
+            Player playerHealth = collision.gameObject.GetComponent<Player>();
+            if (playerHealth != null)
+            {
+                playerHealth.TakeDamage(enemyAttackDamageAmount);
+                gameObject.SetActive(false);
+            }
+        }
+        if (collision.gameObject.CompareTag("Enemy"))
+        {
+            Physics2D.IgnoreCollision(collision.collider, boxCollider);
+        }
+
+    }
+
 }

--- a/Assets/Scripts/Enemy/EnemyAttackPool.cs
+++ b/Assets/Scripts/Enemy/EnemyAttackPool.cs
@@ -54,5 +54,6 @@ public class EnemyAttackPool : MonoBehaviour
         enemyAttack.SetActive(false);
         enemyAttack.transform.position = Vector3.zero;
         enemyAttackObjects.Add(enemyAttack);
+
     }
 }

--- a/Assets/Scripts/Enemy/EnemyHealth.cs
+++ b/Assets/Scripts/Enemy/EnemyHealth.cs
@@ -33,10 +33,28 @@ public class EnemyHealth : MonoBehaviour
     {
         GetComponent<Animator>().SetTrigger("Death");
         yield return new WaitForSeconds(0.5f);
-        gameObject.SetActive(false);
-        currentHealth = maxHealth;
-        GetComponent<ItemBag>().InstantiateItem(transform.position);
-        PointSystem.instance.AddPoint(gameObject.GetComponent<EnemyMovement>().POINTS);
+
+        if (gameObject != null)
+        {
+            gameObject.SetActive(false);
+            currentHealth = maxHealth;
+            GetComponent<ItemBag>().InstantiateItem(transform.position);
+
+            if (PointSystem.instance != null && GetComponent<EnemyMovement>() != null)
+            {
+                PointSystem.instance.AddPoint(gameObject.GetComponent<EnemyMovement>().POINTS);
+            }
+
+            if (GetComponent<EnemySpawner>() != null)
+            {
+                GetComponent<EnemySpawner>().IncreaseDeadCount();
+            }
+
+            if (GetComponent<EnemyMovement>() != null)
+            {
+                GetComponent<EnemyMovement>().EnableAttacking(false);
+            }
+        }
     }
     public float GetCurrentHealth()
     {

--- a/Assets/Scripts/Enemy/EnemyMovement.cs
+++ b/Assets/Scripts/Enemy/EnemyMovement.cs
@@ -21,12 +21,24 @@ public class EnemyMovement : MonoBehaviour
     public int POINTS;
     private Vector3 lastPosition;
     private bool isMovingBack = false;
+    [SerializeField]
+    private bool isAbleAttack = false;
+    [SerializeField]
+    private bool isMoving = false;
+    [SerializeField]
+    private EnemyAttackPool attackPool;
+    [SerializeField]
+    private float attackInterval = 2.5f;
+    private float timer = 0f;
+    private int currentAttackCount = 1;
+
 
     // Start is called before the first frame update
     void Start()
     {
         SetRandomTargetPosition();
         lastPosition = transform.position;
+
     }
 
     // Update is called once per frame
@@ -34,9 +46,10 @@ public class EnemyMovement : MonoBehaviour
     {
         MoveToTargetPosition();
         CheckDirectionAndFlip();
+
     }
 
-    void SetRandomTargetPosition()
+    public void SetRandomTargetPosition()
     {
         float randomX = Random.Range(minX, maxX);
         float randomY = Random.Range(minY, maxY);
@@ -49,7 +62,11 @@ public class EnemyMovement : MonoBehaviour
 
         if (enemyHealth.GetCurrentHealth() <= 0)
         {
-            speed = 0;
+            isMoving = false;
+        }
+        else if(enemyHealth.GetCurrentHealth() >= 1)
+        {
+            isMoving = true;
         }
         if (isMovingBack)
         {
@@ -99,4 +116,34 @@ public class EnemyMovement : MonoBehaviour
     {
         isMovingBack = true;
     }
+    public void EnableAttacking(bool enable)
+    {
+        isAbleAttack = enable;
+    }
+
+    public IEnumerator SpawnAttack(int deadCount)
+    {
+        deadCount = currentAttackCount;
+
+        while (isAbleAttack)
+        {
+            yield return new WaitForSeconds(attackInterval);
+            for (int i = 0; i < currentAttackCount; i++)
+            {
+                if (isAbleAttack == true)
+                {
+                    GameObject attack = attackPool.GetPooledObject();
+                    if (attack != null)
+                    {
+                        attack.transform.position = new Vector3(transform.position.x, transform.position.y + 2, transform.position.z);
+                        attack.SetActive(true);
+                    }
+                }
+                yield return null;
+            }
+
+        }
+    }
+
+
 }

--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -10,6 +10,7 @@ public class EnemySpawner : MonoBehaviour
     [SerializeField] private GameObject el1Prefab;
     [SerializeField] private float spawnInterval = 3f;
     private float spawnTimer;
+    private int deadCount=1;
     private void Awake()
     {
         if (instance == null)
@@ -47,12 +48,20 @@ public class EnemySpawner : MonoBehaviour
             Vector3 spawnPosition = GetFixedSpawnPosition();
             enemy.transform.position = spawnPosition;
             enemy.SetActive(true);
+            
             EnemyHealth enemyHealth = enemy.GetComponent<EnemyHealth>();
             if (enemyHealth != null)
             {
                 enemyHealth.ResetEnemyHealth();
+                enemy.GetComponent<EnemyMovement>().EnableAttacking(true);
+                StartCoroutine(enemy.GetComponent<EnemyMovement>().SpawnAttack(deadCount));
             }
+
         }
+    }
+    public void IncreaseDeadCount()
+    {
+        deadCount++;
     }
 
     public GameObject GetPooledEnemy()
@@ -68,6 +77,6 @@ public class EnemySpawner : MonoBehaviour
     }
     Vector3 GetFixedSpawnPosition()
     {
-        return new Vector3(-1.18f, -6.0f, -0.03689937f);
+        return new Vector3(-0.4f, -3.36f, -0.03689937f);
     }
 }


### PR DESCRIPTION
Damage Touch ( sát thương khi va chạm với player): 
- Các quái có: Level 1,2,3. 
- Hệ số: tăng dần dựa theo level của quái
- Có thể sửa hệ số dmg: 
* Ví dụ sửa Damage Touch của Lv1: trong GameObjec parent Enemy ----> GameObject child Level1 ----> Script EnemyMovement ----> Variable Damage Touch.


Damage Attack ( sát thương từ đòn đánh của enemy): 
- Các quái có: Level 2,3. 
- Hệ số dmg: tăng dần dựa theo level của quái
- Có thể sửa hệ số dmg: 
* Ví dụ sửa Enemy Attack Damge của Lv2: trong GameObjec parent Enemy ----> GameObject child EL2Attack 1 ----> Script Enemy Attack Controller ----> Variable Enemy Attack Damage.

fix bug Enemy khi máu tụt xuống 0 và respawn ra game từ pool không di chuyển và không tấn công

#NOTE: có thể bị lỗi không tìm thấy EnemyMovement script. CHƯA BIẾT TẠI SAO